### PR TITLE
Purge old packages so that they're actually removed

### DIFF
--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -29,7 +29,7 @@ class dell::openmanage (
     'yum-dellsysid',
   ]
   package { $python_smbios_packages:
-    ensure => 'absent',
+    ensure => 'purged',
   }
 
   ########################################


### PR DESCRIPTION
This change causes puppet to forcibly remove old packages installed by old versions of this manifest.
